### PR TITLE
Notebook errors discovered whilst testing

### DIFF
--- a/notebooks/IDR_API_example_script.ipynb
+++ b/notebooks/IDR_API_example_script.ipynb
@@ -357,7 +357,7 @@
    },
    "outputs": [],
    "source": [
-    "THUMBNAIL_URL = \"https://idr.openmicroscopy.org{thumb_url}\"\n",
+    "THUMBNAIL_URL = \"https://idr.openmicroscopy.org/{thumb_url}\"\n",
     "\n",
     "qs = {'thumb_url': thumb_url}\n",
     "url = THUMBNAIL_URL.format(**qs)\n",


### PR DESCRIPTION
- `IDR_API_example_script.ipynb`: Add missing `/` in `THUMBNAIL_URL`

See https://trello.com/c/0SacUNN6/24-update-all-jupyterhub-components