### PR TITLE
first commit of sysgro roi notebook

### DIFF
--- a/notebooks/sysgroRoisReanalysis.ipynb
+++ b/notebooks/sysgroRoisReanalysis.ipynb
@@ -1,0 +1,268 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "from idr import connection\n",
+    "import os\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from pandas import Series,DataFrame,read_csv, merge,concat,read_hdf\n",
+    "import omero\n",
+    "\n",
+    "import skimage.measure as skmes\n",
+    "import skimage.transform as sktrans\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def getBulkAnnotationAsDf(screenID,conn):\n",
+    "#    Download the annotation frile from a screen as a Pandas DataFrame\n",
+    "    sc=conn.getObject('Screen',screenID)\n",
+    "    for ann in sc.listAnnotations():\n",
+    "        if isinstance(ann, omero.gateway.FileAnnotationWrapper):\n",
+    "            if (ann.getFile().getName()=='bulk_annotations'):\n",
+    "                if (ann.getFile().getSize()> 147625090): #about 140Mb?\n",
+    "                    print \"that's a big file...\"\n",
+    "                    return None\n",
+    "                ofId=ann.getFile().getId()\n",
+    "                break\n",
+    "\n",
+    "\n",
+    "    original_file = omero.model.OriginalFileI(ofId, False)\n",
+    "\n",
+    "    openTable = conn.c.sf.sharedResources().openTable(original_file)\n",
+    "    rowCount = openTable.getNumberOfRows()\n",
+    "\n",
+    "    #table to df\n",
+    "\n",
+    "    column_names = [col.name for col in openTable.getHeaders()]\n",
+    "\n",
+    "    black_list = []\n",
+    "    column_indices = []\n",
+    "    for column_name in column_names:\n",
+    "        if column_name in black_list:\n",
+    "            continue\n",
+    "        column_indices.append(column_names.index(column_name))\n",
+    "\n",
+    "    table_data = openTable.slice(column_indices, None)\n",
+    "    data = []\n",
+    "    for index in range(rowCount):\n",
+    "        row_values = [column.values[index] for column in table_data.columns]\n",
+    "        data.append(row_values)\n",
+    "\n",
+    "    dfAnn=DataFrame(data)\n",
+    "    dfAnn.columns=column_names\n",
+    "    return dfAnn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def getLengthsFromStrain(astrain,lenlen=100):\n",
+    "    lengths=[]\n",
+    "    for we in sysgroba[sysgroba[\"Characteristics [Strain]\"]==astrain].Well.values:\n",
+    "        we=conn.getObject('Well',we)\n",
+    "        ii=0\n",
+    "        while True:\n",
+    "            imid=we.getImage(ii)\n",
+    "            ii=ii+1\n",
+    "            if imid == None:\n",
+    "                break\n",
+    "            imId=imid.getId()\n",
+    "            result = roiService.findByImage(imId, None)\n",
+    "            for ii in range(len(result.rois)):\n",
+    "\n",
+    "                #get the coordinates of the outline of the ROI\n",
+    "                s=result.rois[ii].copyShapes()[0]\n",
+    "                pts=s.getPoints().getValue()\n",
+    "                pts=[int(xx) for x in pts.split(' ') for xx in x.split(',') ]\n",
+    "                pts=np.reshape(pts,(len(pts)/2,2))\n",
+    "\n",
+    "                #from coordinates to mask image\n",
+    "                M0,m0,M1,m1=pts[:,0].max(),pts[:,0].min(),pts[:,1].max(),pts[:,1].min()\n",
+    "                imroi=np.zeros((M0-m0+1,M1-m1+1))\n",
+    "                for i in range(pts.shape[0]):\n",
+    "                    imroi[pts[i,0]-m0,pts[i,1]-m1]=1    \n",
+    "\n",
+    "                iml=skmes.label(1-imroi,connectivity=1)\n",
+    "                imroi=1*(iml==iml[iml.shape[0]/2,iml.shape[1]/2])\n",
+    "\n",
+    "                #length of cell as length of bounding box of rotated image (thanks to the particular shape of yeast cells)\n",
+    "                ori=skmes.regionprops(1*imroi)[0].orientation\n",
+    "                imroi=sktrans.rotate(1.*imroi,-ori/(np.pi)*180,resize=True, order=0)\n",
+    "                bbox=skmes.regionprops(skmes.label(imroi))[0].bbox\n",
+    "                lengths.append(bbox[3]-bbox[1])\n",
+    "        if len(lengths)>lenlen: #to speed things up when there are a lot of images...\n",
+    "            break\n",
+    "    return lengths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "conn = connection()\n",
+    "roiService = conn.getRoiService()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#get annotation of a screen\n",
+    "\n",
+    "scId=3 #sysgro\n",
+    "sysgroba=getBulkAnnotationAsDf(scId,conn)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#extract length of cells as stored in ROIs in the IDR\n",
+    "\n",
+    "WTls=getLengthsFromStrain('MS1404',lenlen=200)\n",
+    "ash2ls=getLengthsFromStrain('ash2',lenlen=200)\n",
+    "\n",
+    "pixsize=.11  #could be taken from IDR metadata\n",
+    "ash2ls=[x*pixsize for x in ash2ls]\n",
+    "WTls=[x*pixsize for x in WTls]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD8CAYAAABn919SAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAADfFJREFUeJzt3V+sHPV5xvHnaUwumqDWxgfqppy6VBSVXoSgI8uUNsKi\nEBdVgVRKFVRFViE6iRSiUBWpppFSpF6QtEq4qKpUTm1hVZSmVUJBldNgWZZQJTuqjQwYmWCwHOLg\n2vypClUvWpO3F/s7dHMyc/bf7Ozs6+9HWu3sb39z9mXO+GHO7L47jggBAObfT826AABAMwh0AEiC\nQAeAJAh0AEiCQAeAJAh0AEiCQAeAJAh0AEiCQAeAJNa1+WIbN26MzZs3t/mSADD3jh49+npELAya\n12qgb968WUeOHGnzJQFg7tn+/jDzOOUCAEkQ6ACQBIEOAEkQ6ACQBIEOAEkQ6ACQBIEOAEkQ6ACQ\nBIEOAEm02imKOXPwwerxbfe3WweAoXCEDgBJEOgAkASBDgBJEOgAkASBDgBJEOgAkASBDgBJEOgA\nkASBDgBJEOgAkASBDgBJEOgAkASBDgBJEOgAkASBDgBJEOgAkASBDgBJEOgAkASBDgBJEOgAkASB\nDgBJEOgAkMTAQLd9pe2Dtk/Yft7258v4Btv7bZ8s9+unXy4AoM4wR+gXJP1RRPyqpK2SPmv7Wkk7\nJR2IiKslHSiPAQAzMjDQI+JsRDxdlt+WdELSByTdLmlvmbZX0h3TKhIAMNhI59Btb5b0IUnflXRF\nRJyVeqEv6fKmiwMADG/oQLf9fknflHRvRLw1wnrLto/YPvLaa6+NUyMAYAhDBbrtS9QL80ci4ltl\n+JztTeX5TZLOV60bEbsiYikilhYWFpqoGQBQYZhPuVjSbkknIuKrfU89IWlHWd4h6fHmywMADGvd\nEHNulPRJSc/ZPlbG/kTSlyT9g+27Jb0i6ePTKREAMIyBgR4R/yrJNU/f3Gw5AIBx0SkKAEkQ6ACQ\nBIEOAEkQ6ACQBIEOAEkQ6ACQBIEOAEkQ6ACQBIEOAEkQ6ACQBIEOAEkQ6ACQBIEOAEkQ6ACQBIEO\nAEkQ6ACQBIEOAEkQ6ACQBIEOAEkQ6ACQBIEOAEkQ6ACQBIEOAEkQ6ACQBIEOAEkQ6ACQBIEOAEkQ\n6ACQBIEOAEkQ6ACQBIEOAEkQ6ACQBIEOAEkQ6ACQBIEOAEkQ6ACQxMBAt73H9nnbx/vGHrD9Q9vH\nyu226ZYJABhkmCP0hyVtrxh/KCKuK7d9zZYFABjVwECPiKckvdlCLQCACUxyDv0e28+WUzLrG6sI\nADCWdWOu9zVJfyYpyv1XJN1VNdH2sqRlSVpcXBzz5ebLQ/tfrBz/w1t+peVKWnTwwerxbfe3Wwdw\nERvrCD0izkXEOxHxI0lfl7Rljbm7ImIpIpYWFhbGrRMAMMBYgW57U9/Dj0k6XjcXANCOgadcbD8q\n6SZJG22fkfSnkm6yfZ16p1xOS/r0FGsEAAxhYKBHxJ0Vw7unUAsAYAJ0igJAEgQ6ACRBoANAEgQ6\nACQxbmMRGjTzRqS6piAAc4UjdABIgkAHgCQIdABIgkAHgCQIdABIgkAHgCQIdABIgkAHgCQuvsai\nqiaaWVxVp6+Ora+88e7y4cXl9msBkAJH6ACQBIEOAEkQ6ACQBIEOAEkQ6ACQBIEOAEkQ6ACQBIEO\nAElcfI1Fc2TmVzICMFc4QgeAJAh0AEiCQAeAJAh0AEiCQAeAJAh0AEiCQAeAJAh0AEiCxqIJ1DX+\nDDO//ypFE5nCFZgOnaqu7YarLqt/TQAzxxE6ACRBoANAEgQ6ACRBoANAEgMD3fYe2+dtH+8b22B7\nv+2T5X79dMsEAAwyzBH6w5K2rxrbKelARFwt6UB5DACYoYGBHhFPSXpz1fDtkvaW5b2S7mi4LgDA\niMY9h35FRJyVpHJ/eXMlAQDGMfXGItvLkpYlaXFxcdov147SWLO6Oejw4vJPTN36yq7GX35Qg9Lh\nCz/e8NS1KxxVNWR1rUZgHo17hH7O9iZJKvfn6yZGxK6IWIqIpYWFhTFfDgAwyLiB/oSkHWV5h6TH\nmykHADCuYT62+KikQ5KusX3G9t2SviTpFtsnJd1SHgMAZmjgOfSIuLPmqZsbrgUAMAE6RQEgCQId\nAJIg0AEgCQIdAJLgikV96q5ANO9NLyv/XaubnN69AtGQBl7JqAOy/g6BYXCEDgBJEOgAkASBDgBJ\nEOgAkASBDgBJEOgAkASBDgBJEOgAkASNRWtYacQ5tHvGhcypQ6fekE7d9xPjW6smHyzNSdvur3ju\nweoXqJoLXMQ4QgeAJAh0AEiCQAeAJAh0AEiCQAeAJAh0AEiCQAeAJAh0AEiCxiLp3caVra9UX5Fn\nWKuvCITpOXTqDR2+UH11omniikjoMo7QASAJAh0AkiDQASAJAh0AkiDQASAJAh0AkiDQASAJAh0A\nkpifxqJRr1pTN39OjdK01HaD06FTkzVkreWh/S9O3PC18nOq1DUE1c1v6ucD08AROgAkQaADQBIE\nOgAkQaADQBITvSlq+7SktyW9I+lCRCw1URQAYHRNfMplW0S83sDPAQBMgFMuAJDEpIEekp60fdT2\nchMFAQDGM+kplxsj4lXbl0vab/uFiHiqf0IJ+mVJWlxcnPDlKgxoIKprernhqsuar6UBbTYFTbMh\naF6M2kAEdNlER+gR8Wq5Py/pMUlbKubsioiliFhaWFiY5OUAAGsYO9Btv8/2pSvLkm6VdLypwgAA\no5nklMsVkh6zvfJz/i4i/qWRqgAAIxs70CPilKQPNlgLAGACfGwRAJIg0AEgCQIdAJIg0AEgifm5\nYlHDaKrplpXfx+ELkzf61DVnHV5sv5mZKxmhTRyhA0ASBDoAJEGgA0ASBDoAJEGgA0ASBDoAJEGg\nA0ASBDoAJHHRNhZh/rV5dadZo0EJw+AIHQCSINABIAkCHQCSINABIAkCHQCSINABIAkCHQCSINAB\nIIk0jUVcgSiHaTYLdelKRsA0cIQOAEkQ6ACQBIEOAEkQ6ACQBIEOAEkQ6ACQBIEOAEkQ6ACQRJrG\nImBcozQzNdWEdGj3fVP72dN2UVw96eCD1ePb7h+46iy3D0foAJAEgQ4ASRDoAJAEgQ4ASUwU6La3\n2/6e7Zds72yqKADA6MYOdNvvkfRXkn5b0rWS7rR9bVOFAQBGM8kR+hZJL0XEqYj4H0l/L+n2ZsoC\nAIxqkkD/gKQf9D0+U8YAADPgiBhvRfvjkj4SEZ8qjz8paUtEfG7VvGVJKx0T10j63hA/fqOk18cq\nrH3zUuu81ClR6zTMS50StVb5xYhYGDRpkk7RM5Ku7Hv8C5JeXT0pInZJGum6YraPRMTSBLW1Zl5q\nnZc6JWqdhnmpU6LWSUxyyuXfJF1t+5dsv1fSJyQ90UxZAIBRjX2EHhEXbN8j6TuS3iNpT0Q831hl\nAICRTPTlXBGxT9K+hmrpN71LvzdvXmqdlzolap2GealTotaxjf2mKACgW2j9B4AkZhbotq+xfazv\n9pbte1fNucn2f/bN+WKL9e2xfd728b6xDbb32z5Z7tfXrLujzDlpe8cM6vwL2y/Yftb2Y7Z/tmbd\n07afK9v2yDTrXKPWB2z/sO93fFvNuq1+zURNrd/oq/O07WM167a2XW1fafug7RO2n7f9+TLexX21\nrtZO7a9r1NnJffXHRMTMb+q9qfrv6n3Wsn/8Jkn/PKOaPizpeknH+8b+XNLOsrxT0pcr1tsg6VS5\nX1+W17dc562S1pXlL1fVWZ47LWnjjLfpA5LuG2L/eFnSVZLeK+kZSde2Xeuq578i6Yuz3q6SNkm6\nvixfKulF9b6Ko4v7al2tndpf16izk/tq/60rp1xulvRyRHx/1oWsiIinJL25avh2SXvL8l5Jd1Ss\n+hFJ+yPizYj4D0n7JW1vs86IeDIiLpSHh9XrEZi5mm06jNa/ZmKtWm1b0u9JenSaNQwjIs5GxNNl\n+W1JJ9Tr2O7ivlpZa9f21zW26TBm+pUoXQn0T6j+H8cNtp+x/W3bv9ZmURWuiIizUu+XLunyijld\n+0qEuyR9u+a5kPSk7aOlo3dW7il/bu+pOTXQtW36m5LORcTJmudnsl1tb5b0IUnfVcf31VW19uvU\n/lpRZ6f31ZkHemlK+qikf6x4+mn1TsN8UNJfSvqnNmsbkyvGZvJRIttfkHRB0iM1U26MiOvV+8bM\nz9r+cGvF/b+vSfplSddJOqveqYzVOrNNizu19tF569vV9vslfVPSvRHx1rCrVYxNfbvW1dq1/bWi\nzs7vqzMPdPV+OU9HxLnVT0TEWxHxX2V5n6RLbG9su8A+52xvkqRyf75izlBfiTBt5Q2u35H0+1FO\n7q0WEa+W+/OSHlPvz8VWRcS5iHgnIn4k6es1NXRim0qS7XWSflfSN+rmtL1dbV+iXvA8EhHfKsOd\n3Fdrau3c/lpV5zzsq10I9NqjHds/V85XyvYW9ep9o8XaVntC0sonAXZIerxiznck3Wp7ffmT7NYy\n1hrb2yX9saSPRsR/18x5n+1LV5bVq/N41dxpWgmd4mM1NXTpayZ+S9ILEXGm6sm2t2v597Fb0omI\n+GrfU53bV+tq7dr+ukad3d9X23r3teYd4Z9WL6B/pm/sM5I+U5bvkfS8eu8UH5b06y3W9qh6f1b9\nr3r/171b0mWSDkg6We43lLlLkv6mb927JL1Ubn8wgzpfUu883rFy++sy9+cl7SvLV5Xt+kzZxl+Y\n0Tb9W0nPSXpWvR1/0+pay+Pb1Pu0wcuzqrWMP7yyf/bNndl2lfQb6v1J/2zf7/u2ju6rdbV2an9d\no85O7qv9NzpFASCJLpxyAQA0gEAHgCQIdABIgkAHgCQIdABIgkAHgCQIdABIgkAHgCT+D5sRfz0n\nOJq/AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f2bc32282d0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure()\n",
+    "h1=plt.hist(ash2ls,bins=50, alpha=.5)\n",
+    "h2=plt.hist(WTls,bins=50, alpha=.5)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Ttest_indResult(statistic=-3.9099766965779321, pvalue=0.00010626848336313707)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from scipy.stats import ttest_ind\n",
+    "\n",
+    "ttest_ind(WTls,ash2ls)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# not used"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "#works for deleted gene but maybe not for control strains? \n",
+    "#get images tagged with a given gene using mapr api. (should be able to do it directly without loading annotations?)\n",
+    "\n",
+    "import requests\n",
+    "\n",
+    "INDEX_PAGE = \"https://idr.openmicroscopy.org/webclient/?experimenter=-1\"\n",
+    "\n",
+    "# create http session\n",
+    "with requests.Session() as session:\n",
+    "    request = requests.Request('GET', INDEX_PAGE)\n",
+    "    prepped = session.prepare_request(request)\n",
+    "    response = session.send(prepped)\n",
+    "    if response.status_code != 200:\n",
+    "        response.raise_for_status()\n",
+    "\n",
+    "\n",
+    "agene='tea1'\n",
+    "plate_id=sysgroba[sysgroba[\"Characteristics [Strain]\"]==agene].Plate.values[0]\n",
+    "\n",
+    "IMAGES_URL = \"https://idr.openmicroscopy.org/mapr/api/{key}/images/?value={value}&node={parent_type}&id={parent_id}\"\n",
+    "\n",
+    "qs = {'key': 'gene', 'value': agene, 'parent_type': 'plate', 'parent_id': plate_id}\n",
+    "url = IMAGES_URL.format(**qs)\n",
+    "imIds= session.get(url).json()['images']\n",
+    "imIds=[x['id'] for x in imIds]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "OMERO Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
A simple notebook that compare cell length distribution of Ash2 and control by dowmloading ROIs attached to sysgro images and computing cell length with a very simple algorithm, indeed finding a significant difference (phew! :)) 

Does that fit the/a bill? There is no actual reanalysis of images, since it just reanalyze the cell geometry, and more comment/documentation could be added, but it's a start.

Also I tried to use mapr api (see last cell) but couldn't find my around it (it works well for finding images where a gene is deleted, but control are not tagged by 'gene' -since none are deleted-, but by 'strain' and I wasn't sure how to search by that...)