### PR TITLE
string-db: add species value to workaround error

### DIFF
--- a/notebooks/GeneNetwork.ipynb
+++ b/notebooks/GeneNetwork.ipynb
@@ -481,7 +481,7 @@
    "outputs": [],
    "source": [
     "#building STRINdb REST api query\n",
-    "url = 'http://string-db.org/api/psi-mi-tab/interactionsList?identifiers='\n",
+    "url = 'http://string-db.org/api/psi-mi-tab/interactionsList?species=Human%209606&identifiers='\n",
     "for g in genesE84:\n",
     "    url=url+g+'%250D'\n",
     "Res = requests.get(url)"


### PR DESCRIPTION
The following error was received:

    You have provided a large number of input proteins (> 100), but you have
    not specified an organism. This is rather inefficient - - so please go
    back and specify the organism as well.