### PR TITLE
For discussion: Auto-configure idr.connection from URL

### DIFF
--- a/library/idr.py
+++ b/library/idr.py
@@ -152,7 +152,7 @@ def configuration_from_url(config_url):
     return host, port
 
 
-def connection(host=None, user=None, password=None, port=4064):
+def connection(host=None, user=None, password=None, port=None):
     """
     Connect to the IDR analysis OMERO server
     :return: A BlitzGateway object
@@ -180,7 +180,7 @@ def connection(host=None, user=None, password=None, port=4064):
 
     import omero
     from omero.gateway import BlitzGateway
-    c = omero.client(host)
+    c = omero.client(host, port)
     c.enableKeepAlive(300)
     c.createSession(user, password)
     conn = BlitzGateway(client_obj=c)


### PR DESCRIPTION
When load-balancing with haproxy we can't do proper session pinning with the OMERO binary protocol because there's no way to insert or extract an identifier, so we have to use the client IP. If there are multiple clients behind the same IP such as Jupyterhub this means they'll all hit the same backend server.

To get around this create we can multiple front-end ports with identical backend configuration. If clients connect to a random port the client IP will only be pinned for that front-end port. This should give us the benefit of haproxy's load-balancing and whilst distributing clients from the same IP.

To support autoconfiguration of clients we also create a json config file with a list of connection parameters (`host`, `port`, `user`, `password`, all optional) that clients should randomly choose from.

Example configuration file:
```json
[
    {
        "host": "idr.openmicroscopy.org", 
        "port": 14060
    }, 
    {
        "host": "idr.openmicroscopy.org", 
        "port": 14061
    }, 
    {
        "host": "idr.openmicroscopy.org", 
        "port": 14062
    }, 
    {
        "host": "idr.openmicroscopy.org", 
        "port": 14063
    }, 
    {
        "host": "idr.openmicroscopy.org", 
        "port": 14064
    }, 
    {
        "host": "idr.openmicroscopy.org", 
        "port": 14065
    }, 
    {
        "host": "idr.openmicroscopy.org", 
        "port": 14066
    }, 
    {
        "host": "idr.openmicroscopy.org", 
        "port": 14067
    }, 
    {
        "host": "idr.openmicroscopy.org", 
        "port": 14068
    }, 
    {
        "host": "idr.openmicroscopy.org", 
        "port": 14069
    }
]
```