### PR TITLE
idr-py 0.3.0

### DIFF
--- a/docker/environment-python2-idr.yml
+++ b/docker/environment-python2-idr.yml
@@ -5,7 +5,7 @@ channels:
 - defaults
 dependencies:
 # bioconda
-- idr-py=0.2.1=py27_0
+- idr-py=0.3.0=py27_0
 - gseapy=0.9.2=py27_0
 - python-omero=5.3.3=py27_0
 # conda-forge

--- a/docker/environment-python2-idr.yml
+++ b/docker/environment-python2-idr.yml
@@ -7,7 +7,6 @@ dependencies:
 # bioconda
 - idr-py=0.3.0=py27_0
 - gseapy=0.9.2=py27_0
-- python-omero=5.3.3=py27_0
 # conda-forge
 - bokeh=0.12.15=py27_0
 - joblib=0.11=py27_0


### PR DESCRIPTION
Replaces idr-py with https://github.com/snoopycrimecop/idr-py which should include https://github.com/IDR/idr-py/pull/12