### PR TITLE
Cell growth R notebook: Add warning about the run time

### DIFF
--- a/Yeast_cell_growth.ipynb
+++ b/Yeast_cell_growth.ipynb
@@ -229,7 +229,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Iterate through the timepoints and store the cell count in a dataframe:"
+    "Iterate through the timepoints and store the cell count in a dataframe (warning: this can take **up to 20 min**, use 'seq(1,tmax,7)' to only analyse every seventh image for a quick run):"
    ]
   },
   {
@@ -439,7 +439,8 @@
     "df <- data.frame(TimePoint=integer(),\n",
     "                 CellCount=integer())\n",
     "\n",
-    "for (t in (1:tmax)) {  # use seq(1,tmax,2) to only use every second image (faster)\n",
+    "for (t in (1:tmax)) {\n",
+    "#for (t in seq(1,tmax,7)) { # use seq(1,tmax,7) to only use every seventh image (faster)\n",
     "  count <- countCells(t)\n",
     "  time <- (t * tInMinutes)\n",
     "  df <- rbind(df, c(time, count))\n",
@@ -523,7 +524,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "$$\\rightarrow N = e^{\\:4.7270953\\:+\\:0.0037388\\:*\\:t}\\:;\\:\\text{where N is the number of cells at time t}$$\n",
+    "$$\\rightarrow N = e^{\\:4.72710\\:+\\:0.00374\\:*\\:t}\\:;\\:\\text{where N is the number of cells at time t}$$\n",
     "\n",
     "Very good fit: p-Values < 2e-16, and 97% of the variation is explained by the model!"
    ]


### PR DESCRIPTION
**ITR** 
This PR just adds a warning to the Yeast_Cell_Growth R notebook, because analyzing all 42 images of the timelapse can take quite a bit of time (20 min). Also adds a (commented out) line of code which if uncommented only takes every 7th image into account, if one wants a quick run through the notebook (which still gives a nice result by the way).
