### PR TITLE
Bump baseimage for jupyterlab 0.33

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 ADD docker/environment-python2-idr.yml .setup/
 RUN conda env update -n python2 -f .setup/environment-python2-idr.yml && \
     # Jupyterlab component for bokeh (must match jupyterlab version) \
-    jupyter labextension install jupyterlab_bokeh@^0.5.0
+    jupyter labextension install jupyterlab_bokeh@^0.6.0
 
 RUN /opt/conda/envs/python2/bin/python -m ipykernel install --user --name python2 --display-name 'IDR Python 2'
 ADD docker/logo-32x32.png docker/logo-64x64.png .local/share/jupyter/kernels/python2/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM imagedata/jupyter-docker:0.8.1
+FROM snoopycrimecop/jupyter-docker:master_merge_daily
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 # create a python2 environment (for OMERO-PY compatibility)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM snoopycrimecop/jupyter-docker:master_merge_daily
+FROM imagedata/jupyter-docker:0.8.2
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 # create a python2 environment (for OMERO-PY compatibility)


### PR DESCRIPTION
Bump to `snoopycrimecop/jupyter-docker:master_merge_daily` (which has now been rebuilt on Docker Hub with https://github.com/IDR/jupyter-docker/pull/31)

- [ ] --depends-on https://github.com/IDR/jupyter-docker/pull/31