### PR TITLE
Framework for testing reproducibility of notebooks (rebased onto master)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,8 @@ RUN conda env update -n python2 -q -f .setup/environment-python2-idr.yml && \
 RUN /opt/conda/envs/python2/bin/python -m ipykernel install --user --name python2 --display-name 'IDR Python 2'
 COPY --chown=1000:100 docker/logo-32x32.png docker/logo-64x64.png .local/share/jupyter/kernels/python2/
 
+# Experimental: Install nbval for testing reproducibility of notebooks
+RUN conda install nbval
+
 # Clone the source git repo into notebooks
 COPY --chown=1000:100 . notebooks

--- a/README.ipynb
+++ b/README.ipynb
@@ -72,7 +72,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -17,5 +17,5 @@ docker run -d --name test-jupyter-docker \
     -e IDR_USER="$IDR_USER" \
     -e IDR_PASSWORD="$IDR_PASSWORD" \
     test-jupyter-docker
-docker cp test_notebooks.py test-jupyter-docker:/
-docker exec test-jupyter-docker /opt/conda/envs/python2/bin/pytest /test_notebooks.py
+docker cp test_notebooks.sh test-jupyter-docker:/
+docker exec test-jupyter-docker /test_notebooks.sh

--- a/docker/test_notebooks.sh
+++ b/docker/test_notebooks.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Test notebooks with nbval
+
+set -u
+
+echo_green() {
+    echo -e "\033[0;32m$@\033[0m"
+}
+
+echo_red() {
+    echo -e "\033[0;31m$@\033[0m"
+}
+
+for var in IDR_HOST IDR_USER IDR_PASSWORD; do
+    [ -n "${!var}" ] || {
+        echo_red ERROR: $var is not defined
+        exit 2
+    }
+done
+
+errors=0
+
+# Full reproducibility: output of notebook cells should match the saved cells
+pytest --nbval \
+    notebooks/README.ipynb \
+    notebooks/Using_Jupyter.ipynb \
+
+[ $? -eq 0 ] || {
+    echo_red "FAILED! pytest --nbval"
+    errors=1
+}
+
+# Run without error: don't compare output of cells
+pytest --nbval-lax \
+    notebooks/GeneNetwork.ipynb \
+    notebooks/GenesToPhenotypes.ipynb \
+    notebooks/Getting_Started.ipynb \
+    notebooks/IDR_API_example_script.ipynb \
+
+[ $? -eq 0 ] || {
+    echo_red "FAILED! pytest --nbval-lax"
+    errors=1
+}
+
+[ $errors -eq 0 ] && {
+    echo_green "PASSED!"
+} || {
+    echo_red "FAILED!"
+    exit 2
+}
+
+
+# Not tested
+# pytest.mark.xfail(reason='Takes too long to run')(
+#     'notebooks/CalculateSharpness.ipynb'),
+# pytest.mark.xfail(reason='Requires R')(
+#     'notebooks/CondensationBulkAnnotations.R.ipynb'),
+# pytest.mark.xfail(reason=(
+#     'bokeh.charts replaced by bkcharts. '
+#     'bkcharts is unmaintained and broken '
+#     'https://stackoverflow.com/a/46287065'))(
+#     'notebooks/Figure_1_Sampling_of_Phenotypes.ipynb'),
+# pytest.mark.xfail(reason='Intermittent failures')(
+#     'notebooks/PCAanalysisOfCharmFeatures.ipynb'),
+# pytest.mark.xfail(reason='New notebook, not yet supported')(
+#     'notebooks/QueryIDRWithGeneLists.ipynb'),
+# pytest.mark.xfail(reason='Intermittent failures')(
+#     'notebooks/RohnPhenotypeClustering.ipynb'),
+# pytest.mark.xfail(reason='Takes too long to run')(
+#     'notebooks/SysgroOverview.ipynb'),
+# pytest.mark.xfail(reason='Broken')(
+#     'notebooks/SysgroRoiLength.ipynb'),
+#


### PR DESCRIPTION

This is the same as gh-79 but rebased onto master.

----

Installs [nbval](https://github.com/computationalmodelling/nbval) for testing notebooks.
See the new [`docker/test_notebooks.sh`](https://github.com/IDR/idr-notebooks/pull/79/files#diff-8e7e28203872c8707bed26a055db9c79) script.

There are two ways of running nbval
- `pytest --nbval` runs the notebook and verifies the new output is the same as the output saved in the notebook. [See the nbval docs](https://nbval.readthedocs.io/en/latest/) for ways to modify the output to account for expected variations. Currently only README is tested in this mode
- `pytest --nbval-lax` runs the notebook and checks that no errors occur, but does not check the output. This is equivalent to `jupyter nbconvert --execute ..` in the old `test_notebooks.py` script. Currently only the notebooks that are not marked as `xfail` in `test_notebooks.py` are tested.

In future we should aim to get more notebooks passing under `pytest --nbval`. The forthcoming ITR notebooks may be good candidates.

```
cd docker
IDR_HOST=idr.openmicroscopy.org IDR_USER=public IDR_PASSWORD=<PASSWORD> ./test.sh
```
Example output before README.ipynb was fixed:
![screen shot 2018-08-03 at 16 04 27](https://user-images.githubusercontent.com/1644105/43650820-b042029c-9738-11e8-90ed-d7011361bd99.png)
Example output after fixing README.ipynb (https://github.com/IDR/idr-notebooks/pull/79/commits/b57dd2d1c073d32ea725fba61f8fe0f25e31934a):
![screen shot 2018-08-03 at 16 07 45](https://user-images.githubusercontent.com/1644105/43650840-bb6eaaf8-9738-11e8-830b-a07df17f76b0.png)
:




                