### PR TITLE
Automatically comment on new PRs with mybinder link

### DIFF
--- a/.github/workflows/binder-badge.yaml
+++ b/.github/workflows/binder-badge.yaml
@@ -1,0 +1,12 @@
+#./.github/workflows/binder-badge.yaml
+name: binder-badge
+on:
+  pull_request_target:
+
+jobs:
+  badge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: manics/action-binderbadge@main
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
New PRs (with a base branch after this is merged) should automatically receive a comment on the PR with a link to launch the commit on mybinder.org

![image](https://user-images.githubusercontent.com/1644105/104474245-b8097080-55b5-11eb-9ec9-d1a88451752a.png)
