### PR TITLE
Use tag instead of branch

### DIFF
--- a/humanmine.ipynb
+++ b/humanmine.ipynb
@@ -88,7 +88,7 @@
    ],
    "source": [
     "# Package required to interact with HumanMine\n",
-    "%pip install git+https://github.com/jburel/intermine-ws-python.git@python_3_10"
+    "%pip install git+https://github.com/jburel/intermine-ws-python.git@1.13.1"
    ]
   },
   {
@@ -767,7 +767,7 @@
    "source": [
     "### License (BSD 2-Clause)¶\n",
     "\n",
-    "Copyright (C) 2025 University of Dundee. All Rights Reserved.\n",
+    "Copyright (C) 2025-2026 University of Dundee. All Rights Reserved.\n",
     "\n",
     "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:\n",
     "\n",


### PR DESCRIPTION
Tag the repo and use personal account so we do not follow the dev branch of intermine.
This should be changed when there is an official tag.